### PR TITLE
fix(deps): specify Swift package versions

### DIFF
--- a/app/FastVLM.xcodeproj/project.pbxproj
+++ b/app/FastVLM.xcodeproj/project.pbxproj
@@ -1090,24 +1090,24 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ml-explore/mlx-swift-examples";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.21.2;
+				kind = exactVersion;
+				version = 2.21.2;
 			};
 		};
 		C35EDB8A2D07777E00757E80 /* XCRemoteSwiftPackageReference "mlx-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ml-explore/mlx-swift";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.21.2;
+				kind = exactVersion;
+				version = 0.21.3;
 			};
 		};
 		C3ED54592D790AC6005E20B3 /* XCRemoteSwiftPackageReference "swift-transformers" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/huggingface/swift-transformers";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.18;
+				kind = exactVersion;
+				version = 0.1.19;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
Close #35 

Borrowed from #39, thanks for the correct version @wytalfred provided.

## Context

The following error occurs:

- `apple/ml-fastvlm/app/FastVLM/FastVLM.swift:219:36 Cannot convert value of type 'MLXFast.ScaledDotProductAttentionMaskMode' to expected argument type 'MLXArray'`

```swift
    public func callAsFunction(
            _ inputs: MLXArray?, cache: [KVCache]? = nil, inputEmbedding: MLXArray? = nil
        ) -> MLXArray {
            for (i, layer) in layers.enumerated() {
                h = layer(h, mask: mask, cache: cache?[i]) // <--
            }
        }
```

`apple/ml-fastvlm/app/FastVLM/FastVLM.swift:364:31 Value of type 'UserInput.Prompt' has no member 'asMessages'`:

```swift
    public func prepare(prompt: UserInput.Prompt, imageTHW: THW?) -> String {
        var messages = prompt.asMessages() // <--
    }
```

`apple/ml-fastvlm/app/FastVLM/FastVLM.swift:414:74 Extra argument 'imageGridThw' in call`:

```swift
    public func prepare(input: UserInput) throws -> LMInput {
        let prompt = prepare(prompt: input.prompt, imageTHW: thw) // <--
    }
```

`apple/ml-fastvlm/app/FastVLM/FastVLM.swift:540:36 Value of type 'LMInput.ProcessedImage' has no member 'imageGridThw'`:

```swift
    public func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws
        -> PrepareResult
    {
        let gridThw = input.image?.imageGridThw // <--
    }
```