### PR TITLE
Fix typos: detatch → detach, maxpPositionEmbeddings → maxPositionEmbeddings

### DIFF
--- a/app/FastVLM App/ContentView.swift
+++ b/app/FastVLM App/ContentView.swift
@@ -410,7 +410,7 @@ struct ContentView: View {
             // detach from the camera controller and feed to the video view
             await MainActor.run {
                 self.framesToDisplay = nil
-                self.camera.detatch()
+                self.camera.detach()
             }
 
             framesToDisplayContinuation.finish()

--- a/app/FastVLM/FastVLM.swift
+++ b/app/FastVLM/FastVLM.swift
@@ -585,7 +585,7 @@ public struct FastVLMConfiguration: Codable, Sendable {
         public let vocabularySize: Int
         public let kvHeads: Int
         private let _maxPositionEmbeddings: Int?
-        public var maxpPositionEmbeddings: Int { _maxPositionEmbeddings ?? 32768 }
+        public var maxPositionEmbeddings: Int { _maxPositionEmbeddings ?? 32768 }
         private let _ropeTheta: Float?
         public var ropeTheta: Float { _ropeTheta ?? 1_000_000 }
         private let _ropeTraditional: Bool?

--- a/app/Video/CameraController.swift
+++ b/app/Video/CameraController.swift
@@ -43,7 +43,7 @@ public class CameraController: NSObject {
         }
     }
 
-    public func detatch() {
+    public func detach() {
         sessionQueue.async {
             self.framesContinuation = nil
         }


### PR DESCRIPTION
### Summary

This PR fixes two minor typos:

- In 'CameraController' and 'ContentView', 'detatch()' has been renamed to 'detach()'
- In 'FastVLMConfiguration', 'maxpPositionEmbeddings' has been corrected to 'maxPositionEmbeddings'

### Notes

- Verified build compiles successfully
- No behavior change introduced