### PR TITLE
Fix: missing 'input_ids' in generate of LlavaQwen2ForCausalLM

### DIFF
--- a/llava/model/language_model/llava_qwen.py
+++ b/llava/model/language_model/llava_qwen.py
@@ -112,6 +112,7 @@ class LlavaQwen2ForCausalLM(Qwen2ForCausalLM, LlavaMetaForCausalLM):
     ) -> Union[GenerateOutput, torch.LongTensor]:
         position_ids = kwargs.pop("position_ids", None)
         attention_mask = kwargs.pop("attention_mask", None)
+        inputs = kwargs.pop("input_ids", inputs)
         if "inputs_embeds" in kwargs:
             raise NotImplementedError("`inputs_embeds` is not supported")
 


### PR DESCRIPTION
Clone of [this PR](https://huggingface.co/apple/FastVLM-7B/discussions/9#68bab37109e4ab0ea3f77737) on 🤗 

- Add **input_ids** parsing into the *generate* function, commonly used in 🤗 pipelines

Example:
```python
# Load models
tok = AutoTokenizer.from_pretrained("apple/FastVLM-7B", trust_remote_code=True)
model = AutoModelForCausalLM.from_pretrained(
    "apple/FastVLM-7B",
    torch_dtype=torch.float16 if torch.cuda.is_available() else torch.float32,
    device_map="auto",
    trust_remote_code=True,
)

# Build prompt
messages = [
    {"role": "user", "content": "Describe San Francisco"}
]

# Tokenize
inputs = tokenizer.apply_chat_template(
      messages,
      add_generation_prompt=True,
      tokenize=True,
      return_dict=True,
      return_tensors="pt",
 ).to(model.device)

# Generate  
with torch.no_grad():
    out = model.generate(
        **inputs,
        max_new_tokens=128,
    )

print(tokenizer.decode(out[0], skip_special_tokens=True))

```