### PR TITLE
Fix compatibility with MLX-Swift-Examples v2.25.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,10 @@ dmypy.json
 
 # Xcode
 *.xcworkspace
+xcuserdata/
+*.xcuserstate
+*.xcuserdatad/
+project.pbxproj.orig
 
 # FastVLM models
 app/FastVLM/model

--- a/app/FastVLM/FastVLM.swift
+++ b/app/FastVLM/FastVLM.swift
@@ -213,10 +213,20 @@ private enum Language {
                 fatalError("one of inputs or inputEmbedding must be non-nil")
             }
 
-            let mask = createAttentionMask(h: h, cache: cache)
+            let mask = createAttentionMask(h: h, cache: cache, returnArray: true)
+            let maskArray: MLXArray? = {
+                switch mask {
+                case .array(let array):
+                    return array
+                case .causal, .none:
+                    return nil
+                case .arrays(_):
+                    return nil
+                }
+            }()
 
             for (i, layer) in layers.enumerated() {
-                h = layer(h, mask: mask, cache: cache?[i])
+                h = layer(h, mask: maskArray, cache: cache?[i])
             }
 
             return norm(h)
@@ -361,13 +371,21 @@ public class FastVLMProcessor: UserInputProcessor {
     }
 
     public func prepare(prompt: UserInput.Prompt, imageTHW: THW?) -> String {
-        var messages = prompt.asMessages()
-        if messages[0]["role"] != "system" {
+        var messages: [Message]
+        switch prompt {
+        case .text(let text):
+            messages = [["role": "user", "content": text]]
+        case .messages(let msgs):
+            messages = msgs
+        case .chat(let chatMsgs):
+            messages = chatMsgs.map { ["role": $0.role.rawValue, "content": $0.content] }
+        }
+        if (messages[0]["role"] as? String) != "system" {
             messages.insert(["role": "system", "content": "You are a helpful assistant."], at: 0)
         }
 
         let lastIndex = messages.count - 1
-        var lastMessage = messages[lastIndex]["content"] ?? ""
+        var lastMessage: String = (messages[lastIndex]["content"] as? String) ?? ""
 
         // processing_llava.py
         if let imageTHW {
@@ -382,8 +400,8 @@ public class FastVLMProcessor: UserInputProcessor {
                 numImageTokens -= 1
             }
 
-            lastMessage += Array(repeating: config.imageToken, count: numImageTokens)
-                .joined()
+            let imageTokens = String(repeating: config.imageToken, count: numImageTokens)
+            lastMessage += imageTokens
         }
 
         messages[lastIndex]["content"] = lastMessage
@@ -411,7 +429,7 @@ public class FastVLMProcessor: UserInputProcessor {
 
         let (pixels, thw) = try preprocess(
             image: input.images[0].asCIImage(), processing: input.processing)
-        let image = LMInput.ProcessedImage(pixels: pixels, imageGridThw: [thw])
+        let image = LMInput.ProcessedImage(pixels: pixels, frames: [thw])
 
         let prompt = prepare(prompt: input.prompt, imageTHW: thw)
         let promptTokens = tokenizer.encode(text: prompt)
@@ -537,7 +555,7 @@ public class FastVLM: Module, VLMModel, KVCacheDimensionProvider {
     public func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws
         -> PrepareResult
     {
-        let gridThw = input.image?.imageGridThw
+        let gridThw = input.image?.frames
 
         let dtype = DType.float32
         let pixels = input.image?.pixels.asType(dtype)


### PR DESCRIPTION
# MLX-Swift v2.25.7 Compatibility Changes

## Overview
This document summarizes the changes made to ensure FastVLM compatibility with MLX-Swift-Examples v2.25.7 (Latest package)

## Files Modified
- `.gitignore` (+4 lines)
- `app/FastVLM/FastVLM.swift` (+27 lines, -9 lines)

## Detailed Changes

### 1. .gitignore Updates
Added additional Xcode-related entries to prevent tracking of user-specific files:
```
xcuserdata/
*.xcuserstate
*.xcuserdatad/
project.pbxproj.orig
```

### 2. FastVLM.swift - Attention Mask API Changes

#### Before (v2.25.6 and earlier):
```swift
let mask = createAttentionMask(h: h, cache: cache)
h = layer(h, mask: mask, cache: cache?[i])
```

#### After (v2.25.7 compatible):
```swift
let mask = createAttentionMask(h: h, cache: cache, returnArray: true)
let maskArray: MLXArray? = {
    switch mask {
    case .array(let array):
        return array
    case .causal, .none:
        return nil
    case .arrays(_):
        return nil
    }
}()

for (i, layer) in layers.enumerated() {
    h = layer(h, mask: maskArray, cache: cache?[i])
}
```

**Key Changes:**
- Added `returnArray: true` parameter to `createAttentionMask()`
- Extract `MLXArray` from the returned `AttentionMask` enum
- Pass `MLXArray?` instead of `AttentionMask` to layer functions

### 3. FastVLMProcessor - Message Handling Improvements

#### Before:
```swift
var messages = prompt.asMessages()
if messages[0]["role"] != "system" {
    // ...
}
var lastMessage = messages[lastIndex]["content"] ?? ""
```

#### After:
```swift
var messages: [Message]
switch prompt {
case .text(let text):
    messages = [["role": "user", "content": text]]
case .messages(let msgs):
    messages = msgs
case .chat(let chatMsgs):
    messages = chatMsgs.map { ["role": $0.role.rawValue, "content": $0.content] }
}
if (messages[0]["role"] as? String) != "system" {
    // ...
}
var lastMessage: String = (messages[lastIndex]["content"] as? String) ?? ""
```

**Key Changes:**
- Explicit type casting for dictionary values
- Proper handling of different prompt types
- Improved type safety with explicit `String` casting

### 4. Image Token Processing

#### Before:
```swift
lastMessage += Array(repeating: config.imageToken, count: numImageTokens)
    .joined()
```

#### After:
```swift
let imageTokens = String(repeating: config.imageToken, count: numImageTokens)
lastMessage += imageTokens
```

**Key Changes:**
- Simplified string repetition using `String(repeating:count:)`
- More efficient than creating array and joining

### 5. LMInput.ProcessedImage API Update

#### Before:
```swift
let image = LMInput.ProcessedImage(pixels: pixels, imageGridThw: [thw])
let gridThw = input.image?.imageGridThw
```

#### After:
```swift
let image = LMInput.ProcessedImage(pixels: pixels, frames: [thw])
let gridThw = input.image?.frames
```

**Key Changes:**
- Property renamed from `imageGridThw` to `frames`
- Maintains same functionality with updated API

## Impact
- ✅ Maintains backward compatibility in functionality
- ✅ Fixes compilation errors with MLX-Swift-Examples v2.25.7
- ✅ Improves type safety in message processing
- ✅ Tested and working on iOS device

## Testing Status
- [x] Compilation successful with MLX-Swift-Examples v2.25.7
- [x] iOS device testing completed