### PR TITLE
Fix: update app for mlx-swift-lm 3.x compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,4 +138,10 @@ dmypy.json
 *.xcworkspace
 
 # FastVLM models
-app/FastVLM/model
+app/FastVLM/model/
+
+# Xcode per-user state
+xcuserdata/
+
+# Model checkpoints
+checkpoints/

--- a/README.md
+++ b/README.md
@@ -8,6 +8,27 @@ This is the official repository of
 <img src="docs/acc_vs_latency_qwen-2.png" alt="Accuracy vs latency figure." width="400"/>
 </p>
 
+## Building with Current Packages (June 2026)
+
+> **Note for developers:** This repository was published as a single frozen commit in May 2025.
+> The Swift app no longer builds against current package versions due to breaking changes in
+> `mlx-swift-lm 3.x` and the migration of `MLXLMCommon`/`MLXVLM` out of `mlx-swift-examples`
+> into a new repository.
+>
+> A working fix is available on the
+> [`fix/mlx-swift-lm-3x`](https://github.com/tmorales2000/ml-fastvlm/tree/fix/mlx-swift-lm-3x)
+> branch of this fork, tested on macOS with M1 Pro and M4 Pro against:
+> - `mlx-swift` 0.25.6
+> - `mlx-swift-lm` 3.31.3
+> - `swift-transformers` 1.3.3
+> - `swift-huggingface` 0.9.0
+>
+> See the open [pull request](https://github.com/apple/ml-fastvlm/pull/78) and
+> [issue](https://github.com/apple/ml-fastvlm/issues/77) on Apple's repo for details.
+>
+> **macOS note:** `get_models.sh` and `app/get_pretrained_mlx_model.sh` require `wget`,
+> which is not installed by default on macOS. This fork patches both scripts to use `curl` instead.
+
 ### Highlights
 * We introduce FastViTHD, a novel hybrid vision encoder designed to output fewer tokens and significantly reduce encoding time for high-resolution images.  
 * Our smallest variant outperforms LLaVA-OneVision-0.5B with 85x faster Time-to-First-Token (TTFT) and 3.4x smaller vision encoder.

--- a/app/FastVLM App/FastVLMModel.swift
+++ b/app/FastVLM App/FastVLMModel.swift
@@ -7,9 +7,11 @@ import CoreImage
 import FastVLM
 import Foundation
 import MLX
+import MLXHuggingFace
 import MLXLMCommon
 import MLXRandom
 import MLXVLM
+import Tokenizers
 
 @Observable
 @MainActor
@@ -48,24 +50,26 @@ class FastVLMModel {
     public var evaluationState = EvaluationState.idle
 
     public init() {
-        FastVLM.register(modelFactory: VLMModelFactory.shared)
+        Task {
+            await FastVLM.register(modelFactory: VLMModelFactory.shared)
+        }
     }
 
     private func _load() async throws -> ModelContainer {
         switch loadState {
         case .idle:
             // limit the buffer cache
-            MLX.GPU.set(cacheLimit: 20 * 1024 * 1024)
+            MLX.Memory.cacheLimit = 20 * 1024 * 1024
+
+            let modelDirectory = Bundle(for: FastVLM.self)
+                .url(forResource: "config", withExtension: "json")!
+                .resolvingSymlinksInPath()
+                .deletingLastPathComponent()
 
             let modelContainer = try await VLMModelFactory.shared.loadContainer(
-                configuration: modelConfiguration
-            ) {
-                [modelConfiguration] progress in
-                Task { @MainActor in
-                    self.modelInfo =
-                        "Downloading \(modelConfiguration.name): \(Int(progress.fractionCompleted * 100))%"
-                }
-            }
+                from: modelDirectory,
+                using: #huggingFaceTokenizerLoader()
+            )
             self.modelInfo = "Loaded"
             loadState = .loaded(modelContainer)
             return modelContainer
@@ -115,11 +119,14 @@ class FastVLMModel {
                     let input = try await context.processor.prepare(input: userInput)
                     
                     var seenFirstToken = false
+                    var allTokens = [Int]()
 
                     // FastVLM generates the output
                     let result = try MLXLMCommon.generate(
                         input: input, parameters: generateParameters, context: context
-                    ) { tokens in
+                    ) { token in
+                        allTokens.append(token)
+
                         // Check if task was cancelled
                         if Task.isCancelled {
                             return .stop
@@ -131,7 +138,9 @@ class FastVLMModel {
                             // produced first token, update the time to first token,
                             // the processing state and start displaying the text
                             let llmDuration = Date().timeIntervalSince(llmStart)
-                            let text = context.tokenizer.decode(tokens: tokens)
+                            let text = context.tokenizer.decode(tokenIds: [
+                                token
+                            ])
                             Task { @MainActor in
                                 evaluationState = .generatingResponse
                                 self.output = text
@@ -140,27 +149,29 @@ class FastVLMModel {
                         }
 
                         // Show the text in the view as it generates
-                        if tokens.count % displayEveryNTokens == 0 {
-                            let text = context.tokenizer.decode(tokens: tokens)
+                        if allTokens.count % displayEveryNTokens == 0 {
+                            let text = context.tokenizer.decode(
+                                tokenIds: allTokens
+                            )
                             Task { @MainActor in
                                 self.output = text
                             }
                         }
 
-                        if tokens.count >= maxTokens {
+                        if allTokens.count >= maxTokens {
                             return .stop
                         } else {
                             return .more
                         }
                     }
                     
-                    // Return the duration of the LLM and the result
-                    return result
+                    // Return the final decoded text
+                    return context.tokenizer.decode(tokenIds: allTokens)
                 }
                 
                 // Check if task was cancelled before updating UI
                 if !Task.isCancelled {
-                    self.output = result.output
+                    self.output = result
                 }
 
             } catch {

--- a/app/FastVLM.xcodeproj/project.pbxproj
+++ b/app/FastVLM.xcodeproj/project.pbxproj
@@ -8,19 +8,20 @@
 
 /* Begin PBXBuildFile section */
 		019A3E1A2D78E7370055F93B /* MLX in Frameworks */ = {isa = PBXBuildFile; productRef = 019A3E192D78E7370055F93B /* MLX */; };
-		019A3E1C2D78E73E0055F93B /* MLXLMCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 019A3E1B2D78E73E0055F93B /* MLXLMCommon */; };
 		019A3E1E2D78E7470055F93B /* MLXRandom in Frameworks */ = {isa = PBXBuildFile; productRef = 019A3E1D2D78E7470055F93B /* MLXRandom */; };
-		019A3E202D78E74C0055F93B /* MLXVLM in Frameworks */ = {isa = PBXBuildFile; productRef = 019A3E1F2D78E74C0055F93B /* MLXVLM */; };
 		019A3E212D78E7530055F93B /* Video.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C35372AE2D08C32D00474D34 /* Video.framework */; };
 		019A3E222D78E7530055F93B /* Video.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C35372AE2D08C32D00474D34 /* Video.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		C3ED544E2D790860005E20B3 /* MLXLMCommon in Frameworks */ = {isa = PBXBuildFile; productRef = C3ED544D2D790860005E20B3 /* MLXLMCommon */; };
-		C3ED54502D790860005E20B3 /* MLXVLM in Frameworks */ = {isa = PBXBuildFile; productRef = C3ED544F2D790860005E20B3 /* MLXVLM */; };
 		C3ED54522D790860005E20B3 /* MLX in Frameworks */ = {isa = PBXBuildFile; productRef = C3ED54512D790860005E20B3 /* MLX */; };
 		C3ED54542D790860005E20B3 /* MLXNN in Frameworks */ = {isa = PBXBuildFile; productRef = C3ED54532D790860005E20B3 /* MLXNN */; };
 		C3ED54582D790A68005E20B3 /* MLXFast in Frameworks */ = {isa = PBXBuildFile; productRef = C3ED54572D790A68005E20B3 /* MLXFast */; };
 		C3ED545B2D790AD6005E20B3 /* Transformers in Frameworks */ = {isa = PBXBuildFile; productRef = C3ED545A2D790AD6005E20B3 /* Transformers */; };
 		C3ED55012D7A0A7A005E20B3 /* FastVLM.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C39BB3E62D79082A005DB8FB /* FastVLM.framework */; };
 		C3ED55022D7A0A7A005E20B3 /* FastVLM.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C39BB3E62D79082A005DB8FB /* FastVLM.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		EA383C3E2FD5B8A40013B7C0 /* MLXHuggingFace in Frameworks */ = {isa = PBXBuildFile; productRef = EA383C3D2FD5B8A40013B7C0 /* MLXHuggingFace */; };
+		EA383C402FD5B8A40013B7C0 /* MLXLMCommon in Frameworks */ = {isa = PBXBuildFile; productRef = EA383C3F2FD5B8A40013B7C0 /* MLXLMCommon */; };
+		EA383C422FD5B8A40013B7C0 /* MLXVLM in Frameworks */ = {isa = PBXBuildFile; productRef = EA383C412FD5B8A40013B7C0 /* MLXVLM */; };
+		EA383C452FD5B9240013B7C0 /* HuggingFace in Frameworks */ = {isa = PBXBuildFile; productRef = EA383C442FD5B9240013B7C0 /* HuggingFace */; };
+		EA383C472FD5B9790013B7C0 /* Tokenizers in Frameworks */ = {isa = PBXBuildFile; productRef = EA383C462FD5B9790013B7C0 /* Tokenizers */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -124,12 +125,13 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				019A3E1C2D78E73E0055F93B /* MLXLMCommon in Frameworks */,
+				EA383C3E2FD5B8A40013B7C0 /* MLXHuggingFace in Frameworks */,
+				EA383C472FD5B9790013B7C0 /* Tokenizers in Frameworks */,
 				019A3E212D78E7530055F93B /* Video.framework in Frameworks */,
 				C3ED55012D7A0A7A005E20B3 /* FastVLM.framework in Frameworks */,
 				019A3E1E2D78E7470055F93B /* MLXRandom in Frameworks */,
-				019A3E202D78E74C0055F93B /* MLXVLM in Frameworks */,
 				019A3E1A2D78E7370055F93B /* MLX in Frameworks */,
+				EA383C452FD5B9240013B7C0 /* HuggingFace in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -144,12 +146,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EA383C402FD5B8A40013B7C0 /* MLXLMCommon in Frameworks */,
 				C3ED545B2D790AD6005E20B3 /* Transformers in Frameworks */,
+				EA383C422FD5B8A40013B7C0 /* MLXVLM in Frameworks */,
 				C3ED54522D790860005E20B3 /* MLX in Frameworks */,
-				C3ED54502D790860005E20B3 /* MLXVLM in Frameworks */,
 				C3ED54542D790860005E20B3 /* MLXNN in Frameworks */,
 				C3ED54582D790A68005E20B3 /* MLXFast in Frameworks */,
-				C3ED544E2D790860005E20B3 /* MLXLMCommon in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -228,9 +230,10 @@
 			name = "FastVLM App";
 			packageProductDependencies = (
 				019A3E192D78E7370055F93B /* MLX */,
-				019A3E1B2D78E73E0055F93B /* MLXLMCommon */,
 				019A3E1D2D78E7470055F93B /* MLXRandom */,
-				019A3E1F2D78E74C0055F93B /* MLXVLM */,
+				EA383C3D2FD5B8A40013B7C0 /* MLXHuggingFace */,
+				EA383C442FD5B9240013B7C0 /* HuggingFace */,
+				EA383C462FD5B9790013B7C0 /* Tokenizers */,
 			);
 			productName = FastVLMCameraExample;
 			productReference = 019A3E0A2D78E6A00055F93B /* FastVLM App.app */;
@@ -277,12 +280,12 @@
 			);
 			name = FastVLM;
 			packageProductDependencies = (
-				C3ED544D2D790860005E20B3 /* MLXLMCommon */,
-				C3ED544F2D790860005E20B3 /* MLXVLM */,
 				C3ED54512D790860005E20B3 /* MLX */,
 				C3ED54532D790860005E20B3 /* MLXNN */,
 				C3ED54572D790A68005E20B3 /* MLXFast */,
 				C3ED545A2D790AD6005E20B3 /* Transformers */,
+				EA383C3F2FD5B8A40013B7C0 /* MLXLMCommon */,
+				EA383C412FD5B8A40013B7C0 /* MLXVLM */,
 			);
 			productName = FastVLM;
 			productReference = C39BB3E62D79082A005DB8FB /* FastVLM.framework */;
@@ -320,9 +323,10 @@
 			mainGroup = C35EDB632D07699400757E80;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				C35EDB6A2D076A3900757E80 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */,
 				C35EDB8A2D07777E00757E80 /* XCRemoteSwiftPackageReference "mlx-swift" */,
 				C3ED54592D790AC6005E20B3 /* XCRemoteSwiftPackageReference "swift-transformers" */,
+				EA383C3C2FD5B8A40013B7C0 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */,
+				EA383C432FD5B9240013B7C0 /* XCRemoteSwiftPackageReference "swift-huggingface" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = C35EDB702D076A5A00757E80 /* Products */;
@@ -1086,14 +1090,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		C35EDB6A2D076A3900757E80 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/ml-explore/mlx-swift-examples";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.21.2;
-			};
-		};
 		C35EDB8A2D07777E00757E80 /* XCRemoteSwiftPackageReference "mlx-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ml-explore/mlx-swift";
@@ -1107,8 +1103,28 @@
 			repositoryURL = "https://github.com/huggingface/swift-transformers";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.18;
+				minimumVersion = 1.3.0;
 			};
+			traits = (
+			);
+		};
+		EA383C3C2FD5B8A40013B7C0 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ml-explore/mlx-swift-lm";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.31.3;
+			};
+		};
+		EA383C432FD5B9240013B7C0 /* XCRemoteSwiftPackageReference "swift-huggingface" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/huggingface/swift-huggingface";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.9.0;
+			};
+			traits = (
+			);
 		};
 /* End XCRemoteSwiftPackageReference section */
 
@@ -1118,30 +1134,10 @@
 			package = C35EDB8A2D07777E00757E80 /* XCRemoteSwiftPackageReference "mlx-swift" */;
 			productName = MLX;
 		};
-		019A3E1B2D78E73E0055F93B /* MLXLMCommon */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C35EDB6A2D076A3900757E80 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */;
-			productName = MLXLMCommon;
-		};
 		019A3E1D2D78E7470055F93B /* MLXRandom */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = C35EDB8A2D07777E00757E80 /* XCRemoteSwiftPackageReference "mlx-swift" */;
 			productName = MLXRandom;
-		};
-		019A3E1F2D78E74C0055F93B /* MLXVLM */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C35EDB6A2D076A3900757E80 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */;
-			productName = MLXVLM;
-		};
-		C3ED544D2D790860005E20B3 /* MLXLMCommon */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C35EDB6A2D076A3900757E80 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */;
-			productName = MLXLMCommon;
-		};
-		C3ED544F2D790860005E20B3 /* MLXVLM */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C35EDB6A2D076A3900757E80 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */;
-			productName = MLXVLM;
 		};
 		C3ED54512D790860005E20B3 /* MLX */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -1162,6 +1158,31 @@
 			isa = XCSwiftPackageProductDependency;
 			package = C3ED54592D790AC6005E20B3 /* XCRemoteSwiftPackageReference "swift-transformers" */;
 			productName = Transformers;
+		};
+		EA383C3D2FD5B8A40013B7C0 /* MLXHuggingFace */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EA383C3C2FD5B8A40013B7C0 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
+			productName = MLXHuggingFace;
+		};
+		EA383C3F2FD5B8A40013B7C0 /* MLXLMCommon */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EA383C3C2FD5B8A40013B7C0 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
+			productName = MLXLMCommon;
+		};
+		EA383C412FD5B8A40013B7C0 /* MLXVLM */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EA383C3C2FD5B8A40013B7C0 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */;
+			productName = MLXVLM;
+		};
+		EA383C442FD5B9240013B7C0 /* HuggingFace */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EA383C432FD5B9240013B7C0 /* XCRemoteSwiftPackageReference "swift-huggingface" */;
+			productName = HuggingFace;
+		};
+		EA383C462FD5B9790013B7C0 /* Tokenizers */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C3ED54592D790AC6005E20B3 /* XCRemoteSwiftPackageReference "swift-transformers" */;
+			productName = Tokenizers;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/app/FastVLM/FastVLM.swift
+++ b/app/FastVLM/FastVLM.swift
@@ -103,7 +103,9 @@ private enum Language {
         }
 
         public func callAsFunction(
-            _ x: MLXArray, mask: MLXArray? = nil, cache: KVCache?
+            _ x: MLXArray,
+            mask: MLXFast.ScaledDotProductAttentionMaskMode = .none,
+            cache: KVCache?
         ) -> MLXArray {
             let (B, L) = (x.dim(0), x.dim(1))
 
@@ -117,7 +119,7 @@ private enum Language {
             values = values.reshaped(B, L, kvHeads, headDim).transposed(0, 2, 1, 3)
 
             let offset = cache?.offset ?? 0
-            let mask = mask?[0..., 0 ..< keys.dim(-2)]
+            let mask = mask
 
             queries = rotaryEmbedding(queries, offset: offset)
             keys = rotaryEmbedding(keys, offset: offset)
@@ -171,7 +173,9 @@ private enum Language {
         }
 
         public func callAsFunction(
-            _ x: MLXArray, mask: MLXArray? = nil, cache: KVCache?
+            _ x: MLXArray,
+            mask: MLXFast.ScaledDotProductAttentionMaskMode = .none,
+            cache: KVCache?
         ) -> MLXArray {
             var r = attention(inputLayerNorm(x), mask: mask, cache: cache)
             let h = x + r
@@ -213,7 +217,11 @@ private enum Language {
                 fatalError("one of inputs or inputEmbedding must be non-nil")
             }
 
-            let mask = createAttentionMask(h: h, cache: cache)
+            let mask = createAttentionMask(
+                h: h,
+                cache: cache?.first,
+                windowSize: nil
+            )
 
             for (i, layer) in layers.enumerated() {
                 h = layer(h, mask: mask, cache: cache?[i])
@@ -326,13 +334,16 @@ private enum Vision {
 /// FastVLM `UserInputProcessor`.
 ///
 /// This is meant to be used with ``FastVLM`` and is typically created by ``VLMModelFactory``.
-public class FastVLMProcessor: UserInputProcessor {
+public final class FastVLMProcessor: UserInputProcessor {
 
     private let config: FastVLMProcessorConfiguration
     private let imageProcessingConfig: FastVLMPreProcessorConfiguration
-    private let tokenizer: any Tokenizer
+    private let tokenizer: any MLXLMCommon.Tokenizer
 
-    public init(_ config: FastVLMPreProcessorConfiguration, tokenizer: any Tokenizer) {
+    public init(
+        _ config: FastVLMPreProcessorConfiguration,
+        tokenizer: any MLXLMCommon.Tokenizer
+    ) {
         self.config = FastVLMProcessorConfiguration()
         self.imageProcessingConfig = config
         self.tokenizer = tokenizer
@@ -361,7 +372,22 @@ public class FastVLMProcessor: UserInputProcessor {
     }
 
     public func prepare(prompt: UserInput.Prompt, imageTHW: THW?) -> String {
-        var messages = prompt.asMessages()
+        var messages: [[String: String]]
+        switch prompt {
+        case .messages(let msgs):
+            messages = msgs.compactMap { msg in
+                guard let role = msg["role"] as? String,
+                    let content = msg["content"] as? String
+                else { return nil }
+                return ["role": role, "content": content]
+            }
+        case .text(let text):
+            messages = [["role": "user", "content": text]]
+        case .chat(let chatMessages):
+            messages = chatMessages.map {
+                ["role": $0.role.rawValue, "content": $0.content]
+            }
+        }
         if messages[0]["role"] != "system" {
             messages.insert(["role": "system", "content": "You are a helpful assistant."], at: 0)
         }
@@ -411,7 +437,7 @@ public class FastVLMProcessor: UserInputProcessor {
 
         let (pixels, thw) = try preprocess(
             image: input.images[0].asCIImage(), processing: input.processing)
-        let image = LMInput.ProcessedImage(pixels: pixels, imageGridThw: [thw])
+        let image = LMInput.ProcessedImage(pixels: pixels, frames: [thw])
 
         let prompt = prepare(prompt: input.prompt, imageTHW: thw)
         let promptTokens = tokenizer.encode(text: prompt)
@@ -464,16 +490,24 @@ public class FastVLM: Module, VLMModel, KVCacheDimensionProvider {
         return ModelConfiguration(directory: url)
     }
 
-    static public func register(modelFactory: VLMModelFactory) {
-        modelFactory.typeRegistry.registerModelType("llava_qwen2") { url in
+    @MainActor
+    static public func register(modelFactory: VLMModelFactory) async {
+        await modelFactory.typeRegistry.registerModelType("llava_qwen2") {
+            data in
             let configuration = try JSONDecoder().decode(
-                FastVLMConfiguration.self, from: Data(contentsOf: url))
+                FastVLMConfiguration.self,
+                from: data
+            )
             return FastVLM(configuration)
         }
 
-        modelFactory.processorRegistry.registerProcessorType("LlavaProcessor") { url, tokenizer in
+        await modelFactory.processorRegistry.registerProcessorType(
+            "LlavaProcessor"
+        ) { (data: Data, tokenizer: any MLXLMCommon.Tokenizer) in
             let configuration = try JSONDecoder().decode(
-                FastVLMPreProcessorConfiguration.self, from: Data(contentsOf: url))
+                FastVLMPreProcessorConfiguration.self,
+                from: data
+            )
             return FastVLMProcessor(configuration, tokenizer: tokenizer)
         }
     }
@@ -488,8 +522,12 @@ public class FastVLM: Module, VLMModel, KVCacheDimensionProvider {
     public var vocabularySize: Int { config.baseConfiguration.vocabularySize }
     public var kvHeads: [Int] { languageModel.kvHeads }
 
-    public func loraLinearLayers() -> MLXLMCommon.LoRALinearLayers {
-        languageModel.model.layers.map { ($0.attention, ["q_proj", "v_proj"]) }
+    public var loraLayers: [MLXNN.Module] {
+        languageModel.model.layers
+    }
+
+    public var loraDefaultKeys: [String] {
+        ["q_proj", "v_proj"]
     }
 
     public init(_ config: FastVLMConfiguration) {
@@ -537,7 +575,7 @@ public class FastVLM: Module, VLMModel, KVCacheDimensionProvider {
     public func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws
         -> PrepareResult
     {
-        let gridThw = input.image?.imageGridThw
+        let gridThw = input.image?.frames
 
         let dtype = DType.float32
         let pixels = input.image?.pixels.asType(dtype)

--- a/app/get_pretrained_mlx_model.sh
+++ b/app/get_pretrained_mlx_model.sh
@@ -99,7 +99,7 @@ download_model() {
 
     # Download model
     echo -e "\nDownloading '${model}' model ...\n"
-    wget -q --progress=bar:noscroll --show-progress -O "$tmp_zip_file" "$base_url/$model.zip"
+curl -L --progress-bar "$base_url/$model.zip" -o "$tmp_zip_file"
 
     # Unzip model
     echo -e "\nUnzipping model..."

--- a/get_models.sh
+++ b/get_models.sh
@@ -5,12 +5,12 @@
 #
 
 mkdir -p checkpoints
-wget https://ml-site.cdn-apple.com/datasets/fastvlm/llava-fastvithd_0.5b_stage2.zip -P checkpoints
-wget https://ml-site.cdn-apple.com/datasets/fastvlm/llava-fastvithd_0.5b_stage3.zip -P checkpoints
-wget https://ml-site.cdn-apple.com/datasets/fastvlm/llava-fastvithd_1.5b_stage2.zip -P checkpoints
-wget https://ml-site.cdn-apple.com/datasets/fastvlm/llava-fastvithd_1.5b_stage3.zip -P checkpoints
-wget https://ml-site.cdn-apple.com/datasets/fastvlm/llava-fastvithd_7b_stage2.zip -P checkpoints
-wget https://ml-site.cdn-apple.com/datasets/fastvlm/llava-fastvithd_7b_stage3.zip -P checkpoints
+curl -L https://ml-site.cdn-apple.com/datasets/fastvlm/llava-fastvithd_0.5b_stage2.zip -o checkpoints/llava-fastvithd_0.5b_stage2.zip
+curl -L https://ml-site.cdn-apple.com/datasets/fastvlm/llava-fastvithd_0.5b_stage3.zip -o checkpoints/llava-fastvithd_0.5b_stage3.zip
+curl -L https://ml-site.cdn-apple.com/datasets/fastvlm/llava-fastvithd_1.5b_stage2.zip -o checkpoints/llava-fastvithd_1.5b_stage2.zip
+curl -L https://ml-site.cdn-apple.com/datasets/fastvlm/llava-fastvithd_1.5b_stage3.zip -o checkpoints/llava-fastvithd_1.5b_stage3.zip
+curl -L https://ml-site.cdn-apple.com/datasets/fastvlm/llava-fastvithd_7b_stage2.zip -o checkpoints/llava-fastvithd_7b_stage2.zip
+curl -L https://ml-site.cdn-apple.com/datasets/fastvlm/llava-fastvithd_7b_stage3.zip -o checkpoints/llava-fastvithd_7b_stage3.zip
 
 # Extract models
 cd checkpoints


### PR DESCRIPTION
Fixes #77

The FastVLM app fails to build against current package versions due to breaking 
changes in mlx-swift-lm 3.x and the migration of MLXLMCommon/MLXVLM out of 
mlx-swift-examples into a new repository.

## Changes

**Package dependencies:**
- Replace mlx-swift-examples with mlx-swift-lm 3.x
- Add swift-huggingface 0.9.x
- Update swift-transformers to 1.3.x (exposes Tokenizers as standalone product)

**FastVLM.swift:**
- Update attention mask type to ScaledDotProductAttentionMaskMode
- Fix createAttentionMask signature (windowSize parameter, single cache)
- Fix LoRAModel protocol conformance (loraLayers, loraDefaultKeys)
- Fix UserInput.Prompt handling (asMessages() removed in 3.x)
- Fix LMInput.ProcessedImage (imageGridThw -> frames)
- Fix ModelConfiguration loading API (url -> data in registry closures)
- Fix register() actor isolation (async, await)
- Qualify Tokenizer as MLXLMCommon.Tokenizer to resolve ambiguity

**FastVLMModel.swift:**
- Fix MLX.GPU.set(cacheLimit:) -> MLX.Memory.cacheLimit
- Fix loadContainer API (local directory + huggingFaceTokenizerLoader)
- Fix generate() closure (single Int token, accumulator pattern)
- Fix decode() label (tokens: -> tokenIds:)
- Fix GenerateCompletionInfo (output property removed)

**Scripts:**
- Replace wget with curl in get_models.sh and app/get_pretrained_mlx_model.sh

## Testing

Tested on macOS with M1 Pro and M4 Pro:
- mlx-swift 0.25.6
- mlx-swift-lm 3.31.3
- swift-transformers 1.3.3
- swift-huggingface 0.9.0

App builds and runs successfully with 0.5B (FP16) and 1.5B (INT8) models.